### PR TITLE
Fix json ref issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     install_requires=[
         "singer-python>=5.0.12",
         "requests",
-        "pendulum"
+        "pendulum",
+        "jsonref"
     ],
     entry_points="""
     [console_scripts]

--- a/tap_shipstation/__init__.py
+++ b/tap_shipstation/__init__.py
@@ -1,5 +1,6 @@
 import os
 import json
+import jsonref
 from datetime import datetime
 from datetime import timedelta
 import pendulum
@@ -20,7 +21,7 @@ def load_schemas():
         path = get_abs_path('schemas') + '/' + filename
         file_raw = filename.replace('.json', '')
         with open(path) as file:
-            schemas[file_raw] = json.load(file)
+            schemas[file_raw] = jsonref.load(file)
 
     return schemas
 


### PR DESCRIPTION
The schemas implemented json references, but the `json` library does not properly load the references. This PR fixes that by using the library `jsonrefs`